### PR TITLE
Instructions for Linux and exported Conda env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you have questions contact me on [Twitter](https://twitter.com/FarzaTV).
 
 ### How do I get DeepLeague?
 
-You'll need [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [conda](https://conda.io/docs/user-guide/install/index.html), and [brew](https://brew.sh/). Once you install them you can check if everything works okay by typing in these commands in your terminal. I've confirmed that these steps work on Mac OS. Thing should be VERY similar for Linux as well. You'll just have to use some other method to install packages (like apt-get or whatever you prefer) instead of ```brew``` which I use a few times. Windows Users, you're on your own :(. But it shouldn't be to tough if you know your way around the command line.
+You'll need [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [conda](https://conda.io/docs/user-guide/install/index.html), and [brew](https://brew.sh/). Once you install them you can check if everything works okay by typing in these commands in your terminal. I've confirmed that these steps work on Mac OS. See the steps below to know how to make it work on Linux using Conda. You'll just have to use some other method to install packages (like apt-get or whatever you prefer) instead of ```brew``` which I use a few times. Windows Users, you're on your own :(. But it shouldn't be to tough if you know your way around the command line.
 
 ```sh
 $ conda
@@ -54,8 +54,28 @@ Running that last command is extremely important. It might produce some errors w
 You are almost good to go. Last thing you need is get the [file for the weights](https://drive.google.com/open?id=1-r_4Ex3OC-MTcTwNE7xJkdpiSz_3rb8A). This is the core file behind the magic of DeepLeague
 
 Download this and put it in the /YAD2K directory. The test script will expect it to be here.
-# conda ubuntu framework not needed
-# pythonw not needed
+
+### Instructions for running on Ubuntu 16.04 using Conda
+
+You can install Conda using the guide from  the [official docs](https://conda.io/docs/user-guide/install/linux.html).
+
+```sh
+# get the repo.
+git clone https://github.com/farzaa/DeepLeague.git
+# create the new env
+conda env create -f requirements.yml
+source activate DeepLeague
+
+cd DeepLeague/YAD2K
+
+# Download the weights file
+wget http://pjreddie.com/media/files/yolo.weights
+wget https://archive.org/download/DeepLeagueWeights/trained_stage_3_best.h5
+wget https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/yolo.cfg
+
+# run the command to configure the model
+python yad2k.py yolo.cfg yolo.weights model_data/yolo.h5
+```
 
 ### How do I run DeepLeague?
 Honestly, this repo has so many tiny functions. But, let me explain the easiest way to get this going if all you want to do is analyze a VOD (which most of you want I presume). the ```test_deep_league.py``` is the key to running everything. Its a little command line tool I made that lets you input a VOD to analyze using three different ways: a YouTube link, path to local MP4, path to a directory of images. I like the YouTube link option best, but if you have trouble with it feel free to use the MP4 approach instead. All you need is a 1080P VOD of a League game. Its extremely important its 1080p or else my scripts will incorrectly crop the mini map. Also, DeepLeague is only trained on mini maps from 1080P video. Other sizes aren't tested.
@@ -66,6 +86,9 @@ This command specifies to start at the 30 second mark and end 1 minute in. This 
 
 ```sh
 pythonw test_deep_league.py -out output youtube -yt https://www.youtube.com/watch?v=vPwZW1FvtWA -yt_path /output -start 0:00:30 -end 0:01:00
+
+# if you're using Linux
+python test_deep_league.py -out output youtube -yt https://www.youtube.com/watch?v=vPwZW1FvtWA -yt_path /output -start 0:00:30 -end 0:01:00
 ```
 
 You should first see the download start:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,41 @@
+name: DeepLeague
+channels:
+- menpo
+- defaults
+dependencies:
+- certifi=2016.2.28=py36_0
+- openssl=1.0.2l=0
+- pip=9.0.1=py36_1
+- python=3.6.2=0
+- readline=6.2=2
+- setuptools=36.4.0=py36_1
+- sqlite=3.13.0=0
+- tk=8.5.18=0
+- wheel=0.29.0=py36_0
+- xz=5.2.3=0
+- zlib=1.2.11=0
+- ffmpeg=3.1.3=0
+- pip:
+  - bleach==1.5.0
+  - cycler==0.10.0
+  - enum34==1.1.6
+  - h5py==2.7.1
+  - html5lib==0.9999999
+  - keras==2.1.3
+  - markdown==2.6.11
+  - matplotlib==2.1.2
+  - numpy==1.14.0
+  - opencv-python==3.4.0.12
+  - pillow==5.0.0
+  - protobuf==3.5.1
+  - pyparsing==2.2.0
+  - python-dateutil==2.6.1
+  - pytz==2017.3
+  - pyyaml==3.12
+  - scipy==1.0.0
+  - six==1.11.0
+  - tensorflow==1.4.1
+  - tensorflow-tensorboard==0.4.0
+  - werkzeug==0.14.1
+  - youtube-dl==2018.1.21
+


### PR DESCRIPTION
I created a .yml file with all the packages needed to run it on Linux.

Since the Conda package manager can install packages from pip, a requirements.txt file (like the ones you usually use to run `pip install -r requirements.txt`) is no longer needed.

I tested these steps in both Ubuntu 16.04 and xUbuntu 17.10. The `requirements.yml` is very likely to work on Mac (and windows, for that matter) but I haven't been able to test it yet.