### PR TITLE
Specify tensorflow version 1.15.0 to prevent some errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ conda install python.app # this install python as a framework for mat plot lib
 $ pip install opencv-python youtube_dl
 $ conda install -c menpo ffmpeg
 $ pip install numpy h5py pillow matplotlib
-$ pip install tensorflow
+$ pip install tensorflow==1.15.0
 $ pip install keras
 
 # get the supporting files for the neural net.


### PR DESCRIPTION
1. Error while config
  ```
  AttributeError: module 'tensorflow' has no attribute 'space_to_depth'
  ```
2. Error while running test_deep_league.py
  ```
  Using TensorFlow backend.
  Traceback (most recent call last):
  File "test_deep_league.py", line 152, in <module>
      sess = K.get_session()  # TODO: Remove dependence on Tensorflow session.
  File "/Users/alma/opt/miniconda3/envs/DeepLeague/lib/python3.7/site-packages/keras/backend/tensorflow_backend.py", line 379, in get_session
      '`get_session` is not available '
  RuntimeError: `get_session` is not available when using TensorFlow 2.0.
  ```